### PR TITLE
NAS-140962 / 26.0.0-RC.1 / fix missing dependency (by yocalebo)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -108,6 +108,7 @@ Depends:
  python3-dbus,
  python3-dnspython,
  python3-gssapi,
+ python3-ifaddr,
  python3-jinja2,
  python3-ldap,
  python3-lxml,


### PR DESCRIPTION
This is a hard dependency, otherwise joins to IPA fail with
```
[EFAULT] 1: Traceback (most recent call last):                                       
    File "/usr/local/libexec/ipa_ctl.py", line 19, in                                      
      from ipaclient.install.client import get_ca_certs_from_ldap                       
    File "/usr/lib/python3/dist-packages/ipaclient/install/client.py", line 21, in         
      import ifaddr                            
  ModuleNotFoundError: No module named         
  'ifaddr'

Original PR: https://github.com/truenas/freeipa/pull/7
